### PR TITLE
Support building images with a provided k8s version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /_cache
 /e2e.test
 /kubectl
+/cluster

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 COPY e2e.test /usr/local/bin/
 COPY kubectl /usr/local/bin/
 COPY run_e2e.sh /run_e2e.sh
+COPY cluster /kubernetes/cluster
+WORKDIR /usr/local/bin
 
 ENV E2E_FOCUS="Conformance"
 # NOTE: kubectl tests are temporarily disabled due to the fact that they do not use the in-cluster 

--- a/Makefile
+++ b/Makefile
@@ -53,15 +53,15 @@ _cache/.getbins.$(kube_version_full).timestamp: clean
 container: e2e.test kubectl
 	$(DOCKER) build -t $(REGISTRY)/$(TARGET):latest \
 	                -t $(REGISTRY)/$(TARGET):v$(kube_version) \
-	                -t $(REGISTRY)/$(TARGET):v$(kube_version_full) .
+	                -t $(REGISTRY)/$(TARGET):$(kube_version_full) .
 
 push:
 	$(DOCKER) push $(REGISTRY)/$(TARGET):latest
 	$(DOCKER) push $(REGISTRY)/$(TARGET):v$(kube_version)
-	$(DOCKER) push $(REGISTRY)/$(TARGET):v$(kube_version_full)
+	$(DOCKER) push $(REGISTRY)/$(TARGET):$(kube_version_full)
 
 clean:
 	rm -rf _cache e2e.test kubectl cluster
 	$(DOCKER) rmi $(REGISTRY)/$(TARGET):latest \
 	              $(REGISTRY)/$(TARGET):v$(kube_version) \
-		      $(REGISTRY)/$(TARGET):v$(kube_version_full) || true
+		      $(REGISTRY)/$(TARGET):$(kube_version_full) || true

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,13 @@
 TARGET = kube-conformance
 GOTARGET = github.com/heptio/$(TARGET)
 REGISTRY ?= gcr.io/heptio-images
-KVER = v1.7.3
+KUBE_VERSION ?= 1.7
+kube_version = $(subst v,,$(KUBE_VERSION))
+kube_version_full = $(shell curl https://storage.googleapis.com/kubernetes-release/release/stable-$(kube_version).txt)
 IMAGE = $(REGISTRY)/$(BIN)
-DOCKER ?= docker
+in_docker_group=$(filter docker,$(shell groups))                                                                                                                                                                     
+is_root=$(filter 0,$(shell id -u))
+DOCKER?=$(if $(or $(in_docker_group),$(is_root)),docker,sudo docker)
 DIR := ${CURDIR}
 
 .PHONY: all container getbins clean
@@ -31,25 +35,33 @@ all: container
 e2e.test: getbins
 kubectl: getbins
 
-getbins: | _cache/.getbins.$(KVER).timestamp
+getbins: | _cache/.getbins.$(kube_version_full).timestamp
 
-_cache/.getbins.$(KVER).timestamp:
-	mkdir -p _cache/$(KVER)
-	curl -L -o _cache/$(KVER)/kubernetes.tar.gz http://gcsweb.k8s.io/gcs/kubernetes-release/release/$(KVER)/kubernetes.tar.gz
-	tar -C _cache/$(KVER) -xzf _cache/$(KVER)/kubernetes.tar.gz
-	cd _cache/$(KVER) && KUBERNETES_DOWNLOAD_TESTS=true KUBERNETES_SKIP_CONFIRM=true ./kubernetes/cluster/get-kube-binaries.sh
-	mv _cache/$(KVER)/kubernetes/platforms/linux/amd64/e2e.test ./
-	mv _cache/$(KVER)/kubernetes/platforms/linux/amd64/kubectl ./
-	rm -rf _cache/$(KVER)
+_cache/.getbins.$(kube_version_full).timestamp: clean
+	mkdir -p _cache/$(kube_version_full)
+	curl -L -o _cache/$(kube_version_full)/kubernetes.tar.gz http://gcsweb.k8s.io/gcs/kubernetes-release/release/$(kube_version_full)/kubernetes.tar.gz
+	tar -C _cache/$(kube_version_full) -xzf _cache/$(kube_version_full)/kubernetes.tar.gz
+	cd _cache/$(kube_version_full) && KUBE_VERSION="${kube_version_full}" \
+	                                  KUBERNETES_DOWNLOAD_TESTS=true \
+					  KUBERNETES_SKIP_CONFIRM=true ./kubernetes/cluster/get-kube-binaries.sh
+	mv _cache/$(kube_version_full)/kubernetes/cluster ./
+	mv _cache/$(kube_version_full)/kubernetes/platforms/linux/amd64/e2e.test ./
+	mv _cache/$(kube_version_full)/kubernetes/platforms/linux/amd64/kubectl ./
+	rm -rf _cache/$(kube_version_full)
 	touch $@
 
 container: e2e.test kubectl
-	$(DOCKER) build -t $(REGISTRY)/$(TARGET):latest -t $(REGISTRY)/$(TARGET):$(KVER) .
+	$(DOCKER) build -t $(REGISTRY)/$(TARGET):latest \
+	                -t $(REGISTRY)/$(TARGET):v$(kube_version) \
+	                -t $(REGISTRY)/$(TARGET):v$(kube_version_full) .
 
 push:
 	$(DOCKER) push $(REGISTRY)/$(TARGET):latest
-	$(DOCKER) push $(REGISTRY)/$(TARGET):$(KVER)
+	$(DOCKER) push $(REGISTRY)/$(TARGET):v$(kube_version)
+	$(DOCKER) push $(REGISTRY)/$(TARGET):v$(kube_version_full)
 
 clean:
-	rm -rf _cache e2e.test kubectl
-	$(DOCKER) rmi $(REGISTRY)/$(TARGET):latest $(REGISTRY)/$(TARGET):$(KVER) || true
+	rm -rf _cache e2e.test kubectl cluster
+	$(DOCKER) rmi $(REGISTRY)/$(TARGET):latest \
+	              $(REGISTRY)/$(TARGET):v$(kube_version) \
+		      $(REGISTRY)/$(TARGET):v$(kube_version_full) || true

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GOTARGET = github.com/heptio/$(TARGET)
 REGISTRY ?= gcr.io/heptio-images
 KUBE_VERSION ?= 1.7
 kube_version = $(subst v,,$(KUBE_VERSION))
-kube_version_full = $(shell curl https://storage.googleapis.com/kubernetes-release/release/stable-$(kube_version).txt)
+kube_version_full = $(shell curl -Ss https://storage.googleapis.com/kubernetes-release/release/stable-$(kube_version).txt)
 IMAGE = $(REGISTRY)/$(BIN)
 in_docker_group=$(filter docker,$(shell groups))                                                                                                                                                                     
 is_root=$(filter 0,$(shell id -u))
@@ -39,7 +39,7 @@ getbins: | _cache/.getbins.$(kube_version_full).timestamp
 
 _cache/.getbins.$(kube_version_full).timestamp: clean
 	mkdir -p _cache/$(kube_version_full)
-	curl -L -o _cache/$(kube_version_full)/kubernetes.tar.gz http://gcsweb.k8s.io/gcs/kubernetes-release/release/$(kube_version_full)/kubernetes.tar.gz
+	curl -SsL -o _cache/$(kube_version_full)/kubernetes.tar.gz http://gcsweb.k8s.io/gcs/kubernetes-release/release/$(kube_version_full)/kubernetes.tar.gz
 	tar -C _cache/$(kube_version_full) -xzf _cache/$(kube_version_full)/kubernetes.tar.gz
 	cd _cache/$(kube_version_full) && KUBE_VERSION="${kube_version_full}" \
 	                                  KUBERNETES_DOWNLOAD_TESTS=true \

--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo "/usr/local/bin/e2e.test --ginkgo.skip=\"${E2E_SKIP}\" --ginkgo.focus=\"${E2E_FOCUS}\" --provider=\"${E2E_PROVIDER}\" --report-dir=\"${RESULTS_DIR}\" --ginkgo.noColor=true"
-/usr/local/bin/e2e.test --ginkgo.skip="${E2E_SKIP}" --ginkgo.focus="${E2E_FOCUS}" --provider="${E2E_PROVIDER}" --report-dir="${RESULTS_DIR}" --ginkgo.noColor=true | tee ${RESULTS_DIR}/e2e.log
+echo "/usr/local/bin/e2e.test --repo-root=/kubernetes --ginkgo.skip=\"${E2E_SKIP}\" --ginkgo.focus=\"${E2E_FOCUS}\" --provider=\"${E2E_PROVIDER}\" --report-dir=\"${RESULTS_DIR}\" --ginkgo.noColor=true"
+/usr/local/bin/e2e.test --repo-root=/kubernetes --ginkgo.skip="${E2E_SKIP}" --ginkgo.focus="${E2E_FOCUS}" --provider="${E2E_PROVIDER}" --report-dir="${RESULTS_DIR}" --ginkgo.noColor=true | tee ${RESULTS_DIR}/e2e.log
 # tar up the results for transmission back
 cd ${RESULTS_DIR}
 tar -czf e2e.tar.gz * 


### PR DESCRIPTION
Other enhancements:
- Pre-determine if sudo is needed for docker commands
- Copy kubernetes/cluster into image to support more non-conformance e2e
tests (tested with E2E_FOCUS="Feature:NetworkPolicy")

So now make {container,push} KUBE_VERSION=1.X, etc will get the latest
1.X.Y version of k8s in that minor release range and tag images with
"latest", "v1.X", and "v1.X.Y".