### PR TITLE
Revert "Log client/server versions before starting tests."

### DIFF
--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo "/usr/local/bin/kubectl version"
-/usr/local/bin/kubectl version | tee ${RESULTS_DIR}/version.txt
 echo "/usr/local/bin/e2e.test --repo-root=/kubernetes --ginkgo.skip=\"${E2E_SKIP}\" --ginkgo.focus=\"${E2E_FOCUS}\" --provider=\"${E2E_PROVIDER}\" --report-dir=\"${RESULTS_DIR}\" --kubeconfig=\"${KUBECONFIG}\" --ginkgo.noColor=true"
 /usr/local/bin/e2e.test --repo-root=/kubernetes --ginkgo.skip="${E2E_SKIP}" --ginkgo.focus="${E2E_FOCUS}" --provider="${E2E_PROVIDER}" --report-dir="${RESULTS_DIR}" --kubeconfig="${KUBECONFIG}" --ginkgo.noColor=true | tee ${RESULTS_DIR}/e2e.log
 # tar up the results for transmission back


### PR DESCRIPTION
This reverts commit b102a4c9b3403fffc417a421dc982247468cf602.

This change now exists in the 1.8.1 branch of the e2es and I'm rev'ing the container to pickup. 