### PR TITLE
Update conformance container to latest 1.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 TARGET = kube-conformance
 GOTARGET = github.com/heptio/$(TARGET)
 REGISTRY ?= gcr.io/heptio-images
-latest_stable = 1.8
+latest_stable = 1.9
 KUBE_VERSION ?= $(latest_stable)
 kube_version = $(subst v,,$(KUBE_VERSION))
 kube_version_full = $(shell curl -Ss https://storage.googleapis.com/kubernetes-release/release/stable-$(kube_version).txt)


### PR DESCRIPTION
Hope you don't mind me proposing the update. As 1.9.0 got released and I'm starting conformance testing our stuff for ourselves and for the next PRs to https://github.com/cncf/k8s-conformance/ it would be cool to have your images updated.