### PR TITLE
Proper cleanup

### DIFF
--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -16,6 +16,11 @@
 
 # tar up the results for transmission back
 finish () {
+    # e2e.test responds to INT but not to TERM so we raise TERM to INT.
+    # TODO(chuckha) pkill doesn't seem to have the same effect, find out why
+    PID=$(pgrep e2e.test)
+    kill -INT ${PID}
+    wait ${PID}
     cd "${RESULTS_DIR}"
     tar -czf e2e.tar.gz ./*
     # mark the done file as a termination notice.
@@ -25,5 +30,5 @@ finish () {
 # Write out the done file no matter what happens.
 trap finish EXIT
 
-echo "/usr/local/bin/e2e.test --repo-root=/kubernetes --ginkgo.skip=\"${E2E_SKIP}\" --ginkgo.focus=\"${E2E_FOCUS}\" --provider=\"${E2E_PROVIDER}\" --report-dir=\"${RESULTS_DIR}\" --kubeconfig=\"${KUBECONFIG}\" --ginkgo.noColor=true"
-/usr/local/bin/e2e.test --repo-root=/kubernetes --ginkgo.skip="${E2E_SKIP}" --ginkgo.focus="${E2E_FOCUS}" --provider="${E2E_PROVIDER}" --report-dir="${RESULTS_DIR}" --kubeconfig="${KUBECONFIG}" --ginkgo.noColor=true | tee ${RESULTS_DIR}/e2e.log
+echo "/usr/local/bin/e2e.test --disable-log-dump --repo-root=/kubernetes --ginkgo.skip=\"${E2E_SKIP}\" --ginkgo.focus=\"${E2E_FOCUS}\" --provider=\"${E2E_PROVIDER}\" --report-dir=\"${RESULTS_DIR}\" --kubeconfig=\"${KUBECONFIG}\" --ginkgo.noColor=true"
+/usr/local/bin/e2e.test --disable-log-dump --repo-root=/kubernetes --ginkgo.skip="${E2E_SKIP}" --ginkgo.focus="${E2E_FOCUS}" --provider="${E2E_PROVIDER}" --report-dir="${RESULTS_DIR}" --kubeconfig="${KUBECONFIG}" --ginkgo.noColor=true | tee ${RESULTS_DIR}/e2e.log


### PR DESCRIPTION
This sends INT to the e2e tests so they can cleanup properly.
e2e.test does not respond well to TERM so we capture TERM in
the parent process and send an INT to the child instead.

Also disable log dumping. We have a sonobuoy plugin that does that.

Signed-off-by: Chuck Ha <ha.chuck@gmail.com>