### PR TITLE
Switch to ginkgo to enable parallel test runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /e2e.test
 /kubectl
 /cluster
+/ginkgo

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ ENV E2E_FOCUS="Conformance"
 # configuration atm.  Fixes will be made upstream to resolve.
 ENV E2E_SKIP="Alpha|Disruptive|Feature|Flaky|Kubectl"
 ENV E2E_PROVIDER="local"
+ENV E2E_PARALLEL="1"
 ENV RESULTS_DIR="/tmp/results"
 
 CMD ["/bin/sh", "-c", "/run_e2e.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
     ca-certificates \
     && rm -rf /var/cache/apt/* \
     && rm -rf /var/lib/apt/lists/*
+COPY ginkgo /usr/local/bin/
 COPY e2e.test /usr/local/bin/
 COPY kubectl /usr/local/bin/
 COPY run_e2e.sh /run_e2e.sh

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ all: container
 
 e2e.test: getbins
 kubectl: getbins
+ginkgo: getbins
 
 getbins: | _cache/.getbins.$(kube_version_full).timestamp
 
@@ -47,11 +48,12 @@ _cache/.getbins.$(kube_version_full).timestamp: clean
 					  KUBERNETES_SKIP_CONFIRM=true ./kubernetes/cluster/get-kube-binaries.sh
 	mv _cache/$(kube_version_full)/kubernetes/cluster ./
 	mv _cache/$(kube_version_full)/kubernetes/platforms/linux/amd64/e2e.test ./
+	mv _cache/$(kube_version_full)/kubernetes/platforms/linux/amd64/ginkgo ./
 	mv _cache/$(kube_version_full)/kubernetes/platforms/linux/amd64/kubectl ./
 	rm -rf _cache/$(kube_version_full)
 	touch $@
 
-container: e2e.test kubectl
+container: e2e.test kubectl ginkgo
 	$(DOCKER) build -t $(REGISTRY)/$(TARGET):v$(kube_version) \
 	                -t $(REGISTRY)/$(TARGET):$(kube_version_full) .
 	if [ "$(kube_version)" = "$(latest_stable)" ]; then \
@@ -66,7 +68,7 @@ push:
 	fi
 
 clean:
-	rm -rf _cache e2e.test kubectl cluster
+	rm -rf _cache e2e.test kubectl cluster ginkgo
 	$(DOCKER) rmi $(REGISTRY)/$(TARGET):latest \
 	              $(REGISTRY)/$(TARGET):v$(kube_version) \
 		      $(REGISTRY)/$(TARGET):$(kube_version_full) || true

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ginkgo: getbins
 
 getbins: | _cache/.getbins.$(kube_version_full).timestamp
 
-_cache/.getbins.$(kube_version_full).timestamp: clean
+_cache/.getbins.$(kube_version_full).timestamp:
 	mkdir -p _cache/$(kube_version_full)
 	curl -SsL -o _cache/$(kube_version_full)/kubernetes.tar.gz http://gcsweb.k8s.io/gcs/kubernetes-release/release/$(kube_version_full)/kubernetes.tar.gz
 	tar -C _cache/$(kube_version_full) -xzf _cache/$(kube_version_full)/kubernetes.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ getbins: | _cache/.getbins.$(kube_version_full).timestamp
 
 _cache/.getbins.$(kube_version_full).timestamp:
 	mkdir -p _cache/$(kube_version_full)
-	curl -SsL -o _cache/$(kube_version_full)/kubernetes.tar.gz http://gcsweb.k8s.io/gcs/kubernetes-release/release/$(kube_version_full)/kubernetes.tar.gz
-	tar -C _cache/$(kube_version_full) -xzf _cache/$(kube_version_full)/kubernetes.tar.gz
+	
+	curl -SsL http://gcsweb.k8s.io/gcs/kubernetes-release/release/$(kube_version_full)/kubernetes.tar.gz | tar -C _cache/$(kube_version_full) -xz
 	cd _cache/$(kube_version_full) && KUBE_VERSION="${kube_version_full}" \
 	                                  KUBERNETES_DOWNLOAD_TESTS=true \
 					  KUBERNETES_SKIP_CONFIRM=true ./kubernetes/cluster/get-kube-binaries.sh
@@ -50,7 +50,6 @@ _cache/.getbins.$(kube_version_full).timestamp:
 	mv _cache/$(kube_version_full)/kubernetes/platforms/linux/amd64/e2e.test ./
 	mv _cache/$(kube_version_full)/kubernetes/platforms/linux/amd64/ginkgo ./
 	mv _cache/$(kube_version_full)/kubernetes/platforms/linux/amd64/kubectl ./
-	rm -rf _cache/$(kube_version_full)
 	touch $@
 
 container: e2e.test kubectl ginkgo

--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -24,9 +24,15 @@ shutdown () {
 # We get the TERM from kubernetes and handle it gracefully
 trap shutdown TERM
 
-echo "/usr/local/bin/e2e.test --disable-log-dump --repo-root=/kubernetes --ginkgo.skip=\"${E2E_SKIP}\" --ginkgo.focus=\"${E2E_FOCUS}\" --provider=\"${E2E_PROVIDER}\" --report-dir=\"${RESULTS_DIR}\" --kubeconfig=\"${KUBECONFIG}\" --ginkgo.noColor=true"
-/usr/local/bin/e2e.test --disable-log-dump --repo-root=/kubernetes --ginkgo.skip="${E2E_SKIP}" --ginkgo.focus="${E2E_FOCUS}" --provider="${E2E_PROVIDER}" --report-dir="${RESULTS_DIR}" --kubeconfig="${KUBECONFIG}" --ginkgo.noColor=true | tee ${RESULTS_DIR}/e2e.log &
-# $! is the pid of tee, not e2e.test
+ginkgo_args=(
+    "--focus=${E2E_FOCUS}"
+    "--skip=${E2E_SKIP}"
+    "--noColor=true"
+)
+
+echo "/usr/local/bin/ginkgo ${ginkgo_args[@]} /usr/local/bin/e2e.test -- --disable-log-dump --repo-root=/kubernetes --provider=\"${E2E_PROVIDER}\" --report-dir=\"${RESULTS_DIR}\" --kubeconfig=\"${KUBECONFIG}\""
+/usr/local/bin/ginkgo "${ginkgo_args[@]}" /usr/local/bin/e2e.test -- --disable-log-dump --repo-root=/kubernetes --provider="${E2E_PROVIDER}" --report-dir="${RESULTS_DIR}" --kubeconfig="${KUBECONFIG}" | tee ${RESULTS_DIR}/e2e.log &
+# $! is the pid of tee, not ginkgo
 PID="$(jobs -p)"
 wait "${PID}"
 cd "${RESULTS_DIR}" || exit

--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -30,6 +30,11 @@ ginkgo_args=(
     "--noColor=true"
 )
 
+case ${E2E_PARALLEL} in
+    'y'|'Y')           ginkgo_args+=("--nodes=25") ;;
+    [1-9]|[1-9][0-9]*) ginkgo_args+=("--nodes=${E2E_PARALLEL}") ;;
+esac
+
 echo "/usr/local/bin/ginkgo ${ginkgo_args[@]} /usr/local/bin/e2e.test -- --disable-log-dump --repo-root=/kubernetes --provider=\"${E2E_PROVIDER}\" --report-dir=\"${RESULTS_DIR}\" --kubeconfig=\"${KUBECONFIG}\""
 /usr/local/bin/ginkgo "${ginkgo_args[@]}" /usr/local/bin/e2e.test -- --disable-log-dump --repo-root=/kubernetes --provider="${E2E_PROVIDER}" --report-dir="${RESULTS_DIR}" --kubeconfig="${KUBECONFIG}" | tee ${RESULTS_DIR}/e2e.log &
 # $! is the pid of tee, not ginkgo


### PR DESCRIPTION
This PR switches to use ginkgo which enables parallel e2e runs via `E2E_PARALLEL` env var, which follows test-infra conventions: use `y` or `Y` to get default of 25 ginkgo nodes or specify a numeric value to be more specific. Any other value runs serially.

In testing, this speeds up parallel test runs massively.

~This PR also includes fixes to YAML formatting to use single-quote strings so that regexps can be used more easily without quoting escaping each character requiring escaping. As an example, to skip tests labelled as `[Serial]` current formatting would require specifying `\\[Serial\\]` rather than the more conventional `\[Serial\]` (square brackets need to be escaped as this is a regexp for ginkgo to match tests against).~ _No it doesn't that was in a subsequent sonobuoy PR that takes advantage of this added parallelism..._

There are also a few build improvements that I needed in my journey to this point... minor improvements really but hope they increase outside contributors ability to contribute.