### PR TITLE
Bump version to 1.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 TARGET = kube-conformance
 GOTARGET = github.com/heptio/$(TARGET)
 REGISTRY ?= gcr.io/heptio-images
-latest_stable = 1.13
+latest_stable = 1.14
 KUBE_VERSION ?= $(latest_stable)
 kube_version = $(subst v,,$(KUBE_VERSION))
 kube_version_full = $(shell curl -Ss https://storage.googleapis.com/kubernetes-release/release/stable-$(kube_version).txt)


### PR DESCRIPTION
With the new release of k8s 1.14.0 and the conformance image
bug we found: https://github.com/kubernetes/kubernetes/issues/76036
we wanted to release another version here without the bug so that
users can test their 1.14.0 clusters without worrying about the
hanging behavior.

Signed-off-by: John Schnake <jschnake@vmware.com>